### PR TITLE
Initial stab at Swift 1.2 support.

### DIFF
--- a/HEAnalytics/HEAnalytics.swift
+++ b/HEAnalytics/HEAnalytics.swift
@@ -97,7 +97,7 @@ public class HEAnalytics: NSObject {
                 configDict.enumerateKeysAndObjectsUsingBlock({ (key:AnyObject!, value:AnyObject!, stop:UnsafeMutablePointer<ObjCBool>) -> Void in
                     if let keyString = key as? String {
                         if let valueDictionary = value as? [NSObject:AnyObject] {
-                            let theClass = NSClassFromString(keyString) as HEAnalyticsPlatform.Type
+                            let theClass = NSClassFromString(keyString) as! HEAnalyticsPlatform.Type
                             let platform = theClass(platformData: valueDictionary)
                             self.platforms.append(platform)
                         }

--- a/HEAnalytics/HEAnalyticsPlatformGAI.swift
+++ b/HEAnalytics/HEAnalyticsPlatformGAI.swift
@@ -65,8 +65,9 @@ class HEAnalyticsPlatformGAI: HEAnalyticsPlatform {
         #endif
         }
         
-        let trackingID = platformData["trackingID"] as String
-        GAI.sharedInstance().trackerWithTrackingId(trackingID)
+        if let trackingID = platformData["trackingID"] as? String {
+            GAI.sharedInstance().trackerWithTrackingId(trackingID)
+        }
         
         if let dryRun = platformData["dryRun"] as? Bool {
             GAI.sharedInstance().dryRun = dryRun
@@ -114,7 +115,8 @@ class HEAnalyticsPlatformGAI: HEAnalyticsPlatform {
         if let dataParameters = data.parameters {
             JSONString = HEJSONHelper.canonicalJSONRepresentationWithObject(dataParameters)
         }
-        GAI.sharedInstance().defaultTracker.send(GAIDictionaryBuilder.createEventWithCategory(data.category, action:data.event, label:JSONString, value:nil).build())
+        let sendData = GAIDictionaryBuilder.createEventWithCategory(data.category, action:data.event, label:JSONString, value:nil).build()
+        GAI.sharedInstance().defaultTracker.send(sendData as [NSObject: AnyObject])
     }
 
     
@@ -126,7 +128,7 @@ class HEAnalyticsPlatformGAI: HEAnalyticsPlatform {
         let tracker = GAI.sharedInstance().defaultTracker
         let title = self.viewControlerTitle(viewController)
         tracker.set(kGAIScreenName, value: title)
-        tracker.send(GAIDictionaryBuilder.createScreenView().build())
+        tracker.send(GAIDictionaryBuilder.createScreenView().build() as [NSObject: AnyObject])
     }
 
 }

--- a/HEAnalytics/HEAnalyticsPlatformMixpanel.swift
+++ b/HEAnalytics/HEAnalyticsPlatformMixpanel.swift
@@ -57,8 +57,9 @@ class HEAnalyticsPlatformMixpanel: HEAnalyticsPlatform {
             defaultFlushInterval = flushInterval
         }
 
-        let token = platformData["token"] as String
-        self.mixpanel = Mixpanel(token: token, launchOptions: nil, andFlushInterval: defaultFlushInterval)
+        if let token = platformData["token"] as? String {
+            self.mixpanel = Mixpanel(token: token, launchOptions: nil, andFlushInterval: defaultFlushInterval)
+        }
         
         if let flushOnBackground = platformData["flushOnBackground"] as? Bool {
             self.mixpanel.flushOnBackground = flushOnBackground

--- a/HEAnalytics/HEJSONHelper.swift
+++ b/HEAnalytics/HEJSONHelper.swift
@@ -165,8 +165,10 @@ public class HEJSONHelper: NSObject {
             var keys = sorted(dictionary.keys) {
                 (obj1, obj2) in
 
-                let s1 = obj1 as String
-                let s2 = obj2 as String
+                // NOTE: These forced casts should not fail, but if they do, we'll need to find
+                //       another solution.
+                let s1 = obj1 as! String
+                let s2 = obj2 as! String
                 return s1 < s2
             }
             


### PR DESCRIPTION
This fixes #2 provided it satisfies all the conditions you'd like for Swift 1.2 support. I took a chance I'm not sure we'd wanna take in the Dictionary extension for comparing keys; maybe there's a better solution we could achieve there. Basically anywhere there's a forced cast with a `!` is somewhere we should tread lightly.

No rush on this, either, we can tackle this when we're ready for it.
